### PR TITLE
[codex] Use segmented scan for RF row partitioning

### DIFF
--- a/cpp/src/decisiontree/batched-levelalgo/builder.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder.cuh
@@ -185,8 +185,6 @@ struct Builder {
   IdxT* colids;
   /** temporary row IDs for row-wise out-of-place partitioning */
   IdxT* partition_row_ids;
-  /** per-logical-row left partition ranks from a segmented scan */
-  IdxT* partition_left_offsets;
   /** rmm device workspace buffer */
   rmm::device_uvector<char> d_buff;
   /** pinned host buffer to store the trained nodes */
@@ -281,7 +279,6 @@ struct Builder {
     d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch * dataset.n_sampled_cols);  // colids
     d_wsize +=
       calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);  // partition row IDs
-    d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_blocks_dimx * TPB_DEFAULT);  // left ranks
 
     // all nodes in the tree
     h_wsize +=  // h_workload_info
@@ -325,8 +322,6 @@ struct Builder {
     d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_batch * dataset.n_sampled_cols);
     partition_row_ids = reinterpret_cast<IdxT*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);
-    partition_left_offsets = reinterpret_cast<IdxT*>(d_wspace);
-    d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_blocks_dimx * TPB_DEFAULT);
 
     RAFT_CUDA_TRY(
       cudaMemsetAsync(done_count, 0, sizeof(int) * max_batch * n_col_blks, builder_stream));
@@ -490,7 +485,6 @@ struct Builder {
                                                             workload_info,
                                                             n_blocks_dimx,
                                                             partition_row_ids,
-                                                            partition_left_offsets,
                                                             builder_stream);
     RAFT_CUDA_TRY(cudaPeekAtLastError());
     raft::common::nvtx::pop_range();

--- a/cpp/src/decisiontree/batched-levelalgo/builder.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder.cuh
@@ -475,12 +475,9 @@ struct Builder {
     // create child nodes (or make the current ones leaf)
     raft::common::nvtx::push_range("nodeSplitKernel @builder.cuh [batched-levelalgo]");
     launchNodeSplitKernel<DataT, LabelT, IdxT, TPB_DEFAULT>(params.min_samples_leaf,
-                                                            params.min_samples_split,
-                                                            params.max_leaves,
                                                             params.min_impurity_decrease,
                                                             dataset,
                                                             d_work_items,
-                                                            work_items.size(),
                                                             splits,
                                                             workload_info,
                                                             n_blocks_dimx,

--- a/cpp/src/decisiontree/batched-levelalgo/builder.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder.cuh
@@ -183,14 +183,11 @@ struct Builder {
   /** Memory alignment value */
   const size_t align_value = 512;
   IdxT* colids;
-  /** staging row IDs for out-of-place partitioning */
-  IdxT* tmp_row_ids;
+  /** temporary row IDs for row-wise out-of-place partitioning */
+  IdxT* partition_row_ids;
   /** per-batch child partition counters */
   IdxT* partition_left_counts;
   IdxT* partition_right_counts;
-  /** staging positions for out-of-place partition swaps */
-  IdxT* partition_left_misfit_positions;
-  IdxT* partition_right_misfit_positions;
   /** rmm device workspace buffer */
   rmm::device_uvector<char> d_buff;
   /** pinned host buffer to store the trained nodes */
@@ -283,13 +280,10 @@ struct Builder {
     d_wsize +=                                                                    // workload_info
       calculateAlignedBytes(sizeof(WorkloadInfo<IdxT>) * max_blocks_dimx);
     d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch * dataset.n_sampled_cols);  // colids
-    d_wsize += calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);  // tmp_row_ids
-    d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch);               // left counts
-    d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch);               // right counts
     d_wsize +=
-      calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);  // left misfit positions
-    d_wsize +=
-      calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);  // right misfit positions
+      calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);  // partition row IDs
+    d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch);      // left counts
+    d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch);      // right counts
 
     // all nodes in the tree
     h_wsize +=  // h_workload_info
@@ -331,16 +325,12 @@ struct Builder {
     d_wspace += calculateAlignedBytes(sizeof(WorkloadInfo<IdxT>) * max_blocks_dimx);
     colids = reinterpret_cast<IdxT*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_batch * dataset.n_sampled_cols);
-    tmp_row_ids = reinterpret_cast<IdxT*>(d_wspace);
+    partition_row_ids = reinterpret_cast<IdxT*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);
     partition_left_counts = reinterpret_cast<IdxT*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_batch);
     partition_right_counts = reinterpret_cast<IdxT*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_batch);
-    partition_left_misfit_positions = reinterpret_cast<IdxT*>(d_wspace);
-    d_wspace += calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);
-    partition_right_misfit_positions = reinterpret_cast<IdxT*>(d_wspace);
-    d_wspace += calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);
 
     RAFT_CUDA_TRY(
       cudaMemsetAsync(done_count, 0, sizeof(int) * max_batch * n_col_blks, builder_stream));
@@ -503,11 +493,9 @@ struct Builder {
                                                             splits,
                                                             workload_info,
                                                             n_blocks_dimx,
-                                                            tmp_row_ids,
+                                                            partition_row_ids,
                                                             partition_left_counts,
                                                             partition_right_counts,
-                                                            partition_left_misfit_positions,
-                                                            partition_right_misfit_positions,
                                                             builder_stream);
     RAFT_CUDA_TRY(cudaPeekAtLastError());
     raft::common::nvtx::pop_range();

--- a/cpp/src/decisiontree/batched-levelalgo/builder.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder.cuh
@@ -185,9 +185,8 @@ struct Builder {
   IdxT* colids;
   /** temporary row IDs for row-wise out-of-place partitioning */
   IdxT* partition_row_ids;
-  /** per-batch child partition counters */
-  IdxT* partition_left_counts;
-  IdxT* partition_right_counts;
+  /** per-logical-row left partition ranks from a segmented scan */
+  IdxT* partition_left_offsets;
   /** rmm device workspace buffer */
   rmm::device_uvector<char> d_buff;
   /** pinned host buffer to store the trained nodes */
@@ -282,8 +281,7 @@ struct Builder {
     d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch * dataset.n_sampled_cols);  // colids
     d_wsize +=
       calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);  // partition row IDs
-    d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch);      // left counts
-    d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch);      // right counts
+    d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_blocks_dimx * TPB_DEFAULT);  // left ranks
 
     // all nodes in the tree
     h_wsize +=  // h_workload_info
@@ -327,10 +325,8 @@ struct Builder {
     d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_batch * dataset.n_sampled_cols);
     partition_row_ids = reinterpret_cast<IdxT*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);
-    partition_left_counts = reinterpret_cast<IdxT*>(d_wspace);
-    d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_batch);
-    partition_right_counts = reinterpret_cast<IdxT*>(d_wspace);
-    d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_batch);
+    partition_left_offsets = reinterpret_cast<IdxT*>(d_wspace);
+    d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_blocks_dimx * TPB_DEFAULT);
 
     RAFT_CUDA_TRY(
       cudaMemsetAsync(done_count, 0, sizeof(int) * max_batch * n_col_blks, builder_stream));
@@ -494,8 +490,7 @@ struct Builder {
                                                             workload_info,
                                                             n_blocks_dimx,
                                                             partition_row_ids,
-                                                            partition_left_counts,
-                                                            partition_right_counts,
+                                                            partition_left_offsets,
                                                             builder_stream);
     RAFT_CUDA_TRY(cudaPeekAtLastError());
     raft::common::nvtx::pop_range();

--- a/cpp/src/decisiontree/batched-levelalgo/builder.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/builder.cuh
@@ -183,6 +183,14 @@ struct Builder {
   /** Memory alignment value */
   const size_t align_value = 512;
   IdxT* colids;
+  /** staging row IDs for out-of-place partitioning */
+  IdxT* tmp_row_ids;
+  /** per-batch child partition counters */
+  IdxT* partition_left_counts;
+  IdxT* partition_right_counts;
+  /** staging positions for out-of-place partition swaps */
+  IdxT* partition_left_misfit_positions;
+  IdxT* partition_right_misfit_positions;
   /** rmm device workspace buffer */
   rmm::device_uvector<char> d_buff;
   /** pinned host buffer to store the trained nodes */
@@ -275,6 +283,13 @@ struct Builder {
     d_wsize +=                                                                    // workload_info
       calculateAlignedBytes(sizeof(WorkloadInfo<IdxT>) * max_blocks_dimx);
     d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch * dataset.n_sampled_cols);  // colids
+    d_wsize += calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);  // tmp_row_ids
+    d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch);               // left counts
+    d_wsize += calculateAlignedBytes(sizeof(IdxT) * max_batch);               // right counts
+    d_wsize +=
+      calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);  // left misfit positions
+    d_wsize +=
+      calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);  // right misfit positions
 
     // all nodes in the tree
     h_wsize +=  // h_workload_info
@@ -316,6 +331,16 @@ struct Builder {
     d_wspace += calculateAlignedBytes(sizeof(WorkloadInfo<IdxT>) * max_blocks_dimx);
     colids = reinterpret_cast<IdxT*>(d_wspace);
     d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_batch * dataset.n_sampled_cols);
+    tmp_row_ids = reinterpret_cast<IdxT*>(d_wspace);
+    d_wspace += calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);
+    partition_left_counts = reinterpret_cast<IdxT*>(d_wspace);
+    d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_batch);
+    partition_right_counts = reinterpret_cast<IdxT*>(d_wspace);
+    d_wspace += calculateAlignedBytes(sizeof(IdxT) * max_batch);
+    partition_left_misfit_positions = reinterpret_cast<IdxT*>(d_wspace);
+    d_wspace += calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);
+    partition_right_misfit_positions = reinterpret_cast<IdxT*>(d_wspace);
+    d_wspace += calculateAlignedBytes(sizeof(IdxT) * dataset.n_sampled_rows);
 
     RAFT_CUDA_TRY(
       cudaMemsetAsync(done_count, 0, sizeof(int) * max_batch * n_col_blks, builder_stream));
@@ -476,6 +501,13 @@ struct Builder {
                                                             d_work_items,
                                                             work_items.size(),
                                                             splits,
+                                                            workload_info,
+                                                            n_blocks_dimx,
+                                                            tmp_row_ids,
+                                                            partition_left_counts,
+                                                            partition_right_counts,
+                                                            partition_left_misfit_positions,
+                                                            partition_right_misfit_positions,
                                                             builder_stream);
     RAFT_CUDA_TRY(cudaPeekAtLastError());
     raft::common::nvtx::pop_range();

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
@@ -66,12 +66,9 @@ DI OutT* alignPointer(InT dataset)
 
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
 void launchNodeSplitKernel(const IdxT min_samples_leaf,
-                           const IdxT min_samples_split,
-                           const IdxT max_leaves,
                            const DataT min_impurity_decrease,
                            const Dataset<DataT, LabelT, IdxT>& dataset,
                            const NodeWorkItem* work_items,
-                           size_t work_items_size,
                            const Split<DataT, IdxT>* splits,
                            const WorkloadInfo<IdxT>* workload_info,
                            size_t n_blocks_dimx,

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
@@ -76,7 +76,6 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
                            const WorkloadInfo<IdxT>* workload_info,
                            size_t n_blocks_dimx,
                            IdxT* partition_row_ids,
-                           IdxT* left_offsets,
                            cudaStream_t builder_stream);
 
 template <typename DatasetT, typename NodeT, typename ObjectiveT, typename DataT>

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
@@ -71,8 +71,15 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
                            const DataT min_impurity_decrease,
                            const Dataset<DataT, LabelT, IdxT>& dataset,
                            const NodeWorkItem* work_items,
-                           const size_t work_items_size,
+                           size_t work_items_size,
                            const Split<DataT, IdxT>* splits,
+                           const WorkloadInfo<IdxT>* workload_info,
+                           size_t n_blocks_dimx,
+                           IdxT* tmp_row_ids,
+                           IdxT* left_counts,
+                           IdxT* right_counts,
+                           IdxT* left_misfit_positions,
+                           IdxT* right_misfit_positions,
                            cudaStream_t builder_stream);
 
 template <typename DatasetT, typename NodeT, typename ObjectiveT, typename DataT>

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
@@ -76,8 +76,7 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
                            const WorkloadInfo<IdxT>* workload_info,
                            size_t n_blocks_dimx,
                            IdxT* partition_row_ids,
-                           IdxT* left_counts,
-                           IdxT* right_counts,
+                           IdxT* left_offsets,
                            cudaStream_t builder_stream);
 
 template <typename DatasetT, typename NodeT, typename ObjectiveT, typename DataT>

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels.cuh
@@ -75,11 +75,9 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
                            const Split<DataT, IdxT>* splits,
                            const WorkloadInfo<IdxT>* workload_info,
                            size_t n_blocks_dimx,
-                           IdxT* tmp_row_ids,
+                           IdxT* partition_row_ids,
                            IdxT* left_counts,
                            IdxT* right_counts,
-                           IdxT* left_misfit_positions,
-                           IdxT* right_misfit_positions,
                            cudaStream_t builder_stream);
 
 template <typename DatasetT, typename NodeT, typename ObjectiveT, typename DataT>

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
@@ -77,23 +77,164 @@ DI void partitionSamples(const Dataset<DataT, LabelT, IdxT>& dataset,
     }
   }
 }
+
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
-static __global__ void nodeSplitKernel(const IdxT min_samples_leaf,
-                                       const IdxT min_samples_split,
-                                       const IdxT max_leaves,
-                                       const DataT min_impurity_decrease,
-                                       const Dataset<DataT, LabelT, IdxT> dataset,
-                                       const NodeWorkItem* work_items,
-                                       const Split<DataT, IdxT>* splits)
+static __global__ void nodeSplitCopySourceKernel(const IdxT min_samples_leaf,
+                                                 const IdxT min_samples_split,
+                                                 const IdxT max_leaves,
+                                                 const DataT min_impurity_decrease,
+                                                 const Dataset<DataT, LabelT, IdxT> dataset,
+                                                 const NodeWorkItem* work_items,
+                                                 const Split<DataT, IdxT>* splits,
+                                                 const WorkloadInfo<IdxT>* workload_info,
+                                                 IdxT* tmp_row_ids)
 {
-  extern __shared__ char smem[];
-  const auto work_item = work_items[blockIdx.x];
-  const auto split     = splits[blockIdx.x];
+  const auto workload_info_cta = workload_info[blockIdx.x];
+  const auto nid               = workload_info_cta.nodeid;
+  const auto work_item         = work_items[nid];
+  const auto split             = splits[nid];
   if (SplitNotValid(
         split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
     return;
   }
-  partitionSamples<DataT, LabelT, IdxT, TPB>(dataset, split, work_item, (char*)smem);
+
+  const auto range_start = work_item.instances.begin;
+  const auto range_len   = work_item.instances.count;
+  const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * blockDim.x + threadIdx.x;
+  if (range_pos < range_len) {
+    const auto idx   = range_start + range_pos;
+    tmp_row_ids[idx] = dataset.row_ids[idx];
+  }
+}
+
+template <typename DataT, typename LabelT, typename IdxT, int TPB>
+static __global__ void nodeSplitMisfitKernel(const IdxT min_samples_leaf,
+                                             const IdxT min_samples_split,
+                                             const IdxT max_leaves,
+                                             const DataT min_impurity_decrease,
+                                             const Dataset<DataT, LabelT, IdxT> dataset,
+                                             const NodeWorkItem* work_items,
+                                             const Split<DataT, IdxT>* splits,
+                                             const WorkloadInfo<IdxT>* workload_info,
+                                             IdxT* left_counts,
+                                             IdxT* right_counts,
+                                             IdxT* left_misfit_positions,
+                                             IdxT* right_misfit_positions)
+{
+  typedef cub::BlockScan<int, TPB> BlockScanT;
+  __shared__ typename BlockScanT::TempStorage left_scan;
+  __shared__ typename BlockScanT::TempStorage right_scan;
+  __shared__ IdxT left_base;
+  __shared__ IdxT right_base;
+
+  const auto workload_info_cta = workload_info[blockIdx.x];
+  const auto nid               = workload_info_cta.nodeid;
+  const auto work_item         = work_items[nid];
+  const auto split             = splits[nid];
+  if (SplitNotValid(
+        split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
+    return;
+  }
+
+  const auto range_start = work_item.instances.begin;
+  const auto range_len   = work_item.instances.count;
+  const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * blockDim.x + threadIdx.x;
+  const bool valid       = range_pos < range_len;
+
+  IdxT row = 0;
+  bool goes_left{false};
+  if (valid) {
+    row                 = dataset.row_ids[range_start + range_pos];
+    std::size_t col_idx = std::size_t(split.colid) * dataset.M + row;
+    goes_left           = dataset.data[col_idx] <= split.quesval;
+  }
+
+  const bool in_left_range = range_pos < std::size_t(split.nLeft);
+  const int left_flag      = valid && in_left_range && !goes_left;
+  const int right_flag     = valid && !in_left_range && goes_left;
+
+  int left_rank, left_total;
+  int right_rank, right_total;
+  BlockScanT(left_scan).ExclusiveSum(left_flag, left_rank, left_total);
+  BlockScanT(right_scan).ExclusiveSum(right_flag, right_rank, right_total);
+
+  if (threadIdx.x == 0) {
+    left_base  = atomicAdd(left_counts + nid, IdxT(left_total));
+    right_base = atomicAdd(right_counts + nid, IdxT(right_total));
+  }
+  __syncthreads();
+
+  if (left_flag) {
+    left_misfit_positions[range_start + left_base + left_rank] = range_start + range_pos;
+  }
+  if (right_flag) {
+    right_misfit_positions[range_start + right_base + right_rank] = range_start + range_pos;
+  }
+}
+
+template <typename DataT, typename LabelT, typename IdxT, int TPB>
+static __global__ void nodeSplitSwapMisfitsKernel(const IdxT min_samples_leaf,
+                                                  const IdxT min_samples_split,
+                                                  const IdxT max_leaves,
+                                                  const DataT min_impurity_decrease,
+                                                  const Dataset<DataT, LabelT, IdxT> dataset,
+                                                  const NodeWorkItem* work_items,
+                                                  const Split<DataT, IdxT>* splits,
+                                                  const WorkloadInfo<IdxT>* workload_info,
+                                                  const IdxT* left_counts,
+                                                  const IdxT* right_counts,
+                                                  const IdxT* left_misfit_positions,
+                                                  const IdxT* right_misfit_positions,
+                                                  IdxT* tmp_row_ids)
+{
+  const auto workload_info_cta = workload_info[blockIdx.x];
+  const auto nid               = workload_info_cta.nodeid;
+  const auto work_item         = work_items[nid];
+  const auto split             = splits[nid];
+  if (SplitNotValid(
+        split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
+    return;
+  }
+
+  const auto range_start = work_item.instances.begin;
+  const auto range_len   = work_item.instances.count;
+  const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * blockDim.x + threadIdx.x;
+  const auto n_swaps     = min(left_counts[nid], right_counts[nid]);
+  if (range_pos < range_len && range_pos < std::size_t(n_swaps)) {
+    const auto left_pos    = left_misfit_positions[range_start + range_pos];
+    const auto right_pos   = right_misfit_positions[range_start + range_pos];
+    tmp_row_ids[left_pos]  = dataset.row_ids[right_pos];
+    tmp_row_ids[right_pos] = dataset.row_ids[left_pos];
+  }
+}
+
+template <typename DataT, typename LabelT, typename IdxT, int TPB>
+static __global__ void nodeSplitCopyBackKernel(const IdxT min_samples_leaf,
+                                               const IdxT min_samples_split,
+                                               const IdxT max_leaves,
+                                               const DataT min_impurity_decrease,
+                                               const Dataset<DataT, LabelT, IdxT> dataset,
+                                               const NodeWorkItem* work_items,
+                                               const Split<DataT, IdxT>* splits,
+                                               const WorkloadInfo<IdxT>* workload_info,
+                                               const IdxT* tmp_row_ids)
+{
+  const auto workload_info_cta = workload_info[blockIdx.x];
+  const auto nid               = workload_info_cta.nodeid;
+  const auto work_item         = work_items[nid];
+  const auto split             = splits[nid];
+  if (SplitNotValid(
+        split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
+    return;
+  }
+
+  const auto range_start = work_item.instances.begin;
+  const auto range_len   = work_item.instances.count;
+  const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * blockDim.x + threadIdx.x;
+  if (range_pos < range_len) {
+    const auto idx       = range_start + range_pos;
+    dataset.row_ids[idx] = tmp_row_ids[idx];
+  }
 }
 
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
@@ -103,19 +244,67 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
                            const DataT min_impurity_decrease,
                            const Dataset<DataT, LabelT, IdxT>& dataset,
                            const NodeWorkItem* work_items,
-                           const size_t work_items_size,
+                           size_t work_items_size,
                            const Split<DataT, IdxT>* splits,
+                           const WorkloadInfo<IdxT>* workload_info,
+                           size_t n_blocks_dimx,
+                           IdxT* tmp_row_ids,
+                           IdxT* left_counts,
+                           IdxT* right_counts,
+                           IdxT* left_misfit_positions,
+                           IdxT* right_misfit_positions,
                            cudaStream_t builder_stream)
 {
-  auto constexpr smem_size = 2 * sizeof(IdxT) * TPB;
-  nodeSplitKernel<DataT, LabelT, IdxT, TPB>
-    <<<work_items_size, TPB, smem_size, builder_stream>>>(min_samples_leaf,
-                                                          min_samples_split,
-                                                          max_leaves,
-                                                          min_impurity_decrease,
-                                                          dataset,
-                                                          work_items,
-                                                          splits);
+  if (n_blocks_dimx == 0) return;
+  RAFT_CUDA_TRY(cudaMemsetAsync(left_counts, 0, sizeof(IdxT) * work_items_size, builder_stream));
+  RAFT_CUDA_TRY(cudaMemsetAsync(right_counts, 0, sizeof(IdxT) * work_items_size, builder_stream));
+  nodeSplitCopySourceKernel<DataT, LabelT, IdxT, TPB>
+    <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
+                                                min_samples_split,
+                                                max_leaves,
+                                                min_impurity_decrease,
+                                                dataset,
+                                                work_items,
+                                                splits,
+                                                workload_info,
+                                                tmp_row_ids);
+  nodeSplitMisfitKernel<DataT, LabelT, IdxT, TPB>
+    <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
+                                                min_samples_split,
+                                                max_leaves,
+                                                min_impurity_decrease,
+                                                dataset,
+                                                work_items,
+                                                splits,
+                                                workload_info,
+                                                left_counts,
+                                                right_counts,
+                                                left_misfit_positions,
+                                                right_misfit_positions);
+  nodeSplitSwapMisfitsKernel<DataT, LabelT, IdxT, TPB>
+    <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
+                                                min_samples_split,
+                                                max_leaves,
+                                                min_impurity_decrease,
+                                                dataset,
+                                                work_items,
+                                                splits,
+                                                workload_info,
+                                                left_counts,
+                                                right_counts,
+                                                left_misfit_positions,
+                                                right_misfit_positions,
+                                                tmp_row_ids);
+  nodeSplitCopyBackKernel<DataT, LabelT, IdxT, TPB>
+    <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
+                                                min_samples_split,
+                                                max_leaves,
+                                                min_impurity_decrease,
+                                                dataset,
+                                                work_items,
+                                                splits,
+                                                workload_info,
+                                                tmp_row_ids);
 }
 
 template <typename DatasetT, typename NodeT, typename ObjectiveT, typename DataT>
@@ -377,8 +566,15 @@ template void launchNodeSplitKernel<_DataT, _LabelT, _IdxT, TPB_DEFAULT>(
   const _DataT min_impurity_decrease,
   const Dataset<_DataT, _LabelT, _IdxT>& dataset,
   const NodeWorkItem* work_items,
-  const size_t work_items_size,
+  size_t work_items_size,
   const Split<_DataT, _IdxT>* splits,
+  const WorkloadInfo<_IdxT>* workload_info,
+  size_t n_blocks_dimx,
+  _IdxT* tmp_row_ids,
+  _IdxT* left_counts,
+  _IdxT* right_counts,
+  _IdxT* left_misfit_positions,
+  _IdxT* right_misfit_positions,
   cudaStream_t builder_stream);
 
 template void launchLeafKernel<_DatasetT, _NodeT, _ObjectiveT, _DataT>(

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
@@ -16,8 +16,8 @@
 #include <cub/cub.cuh>
 #include <thrust/binary_search.h>
 #include <thrust/execution_policy.h>
-#include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/tabulate_output_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/scan.h>
 
@@ -27,6 +27,41 @@ namespace ML {
 namespace DT {
 
 static constexpr int TPB_DEFAULT = 128;
+
+template <typename DataT, typename LabelT, typename IdxT, int TPB>
+struct NodeSplitPartitionWriter {
+  IdxT min_samples_leaf;
+  DataT min_impurity_decrease;
+  Dataset<DataT, LabelT, IdxT> dataset;
+  const NodeWorkItem* work_items;
+  const Split<DataT, IdxT>* splits;
+  const WorkloadInfo<IdxT>* workload_info;
+  IdxT* partition_row_ids;
+
+  __host__ __device__ void operator()(std::ptrdiff_t index, IdxT left_rank) const
+  {
+    const auto slot              = std::size_t(index);
+    const auto workload_info_cta = workload_info[slot / TPB];
+    const auto nid               = workload_info_cta.nodeid;
+    const auto work_item         = work_items[nid];
+    const auto split             = splits[nid];
+    if (SplitNotValid(
+          split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
+      return;
+    }
+
+    const auto range_start = work_item.instances.begin;
+    const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * TPB + slot % TPB;
+    if (range_pos >= work_item.instances.count) { return; }
+
+    const auto row       = dataset.row_ids[range_start + range_pos];
+    const auto col_idx   = std::size_t(split.colid) * dataset.M + row;
+    const bool goes_left = dataset.data[col_idx] <= split.quesval;
+    const auto rank      = goes_left ? left_rank : IdxT(range_pos) - left_rank;
+    const auto out_idx   = range_start + (goes_left ? rank : split.nLeft + rank);
+    partition_row_ids[out_idx] = row;
+  }
+};
 
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
 static __global__ void nodeSplitCopyBackKernel(const IdxT min_samples_leaf,
@@ -69,7 +104,6 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
                            const WorkloadInfo<IdxT>* workload_info,
                            size_t n_blocks_dimx,
                            IdxT* partition_row_ids,
-                           IdxT* left_offsets,
                            cudaStream_t builder_stream)
 {
   (void)work_items_size;
@@ -78,7 +112,6 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
   const auto n_slots = n_blocks_dimx * TPB;
   auto exec_policy   = rmm::exec_policy(builder_stream);
   auto slots_begin   = thrust::make_counting_iterator<std::size_t>(0);
-  auto slots_end     = slots_begin + n_slots;
 
   auto node_key = [workload_info] __host__ __device__(std::size_t slot) {
     return workload_info[slot / TPB].nodeid;
@@ -106,31 +139,16 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
     return left_predicate(slot) ? IdxT(1) : IdxT(0);
   };
   auto left_flags = thrust::make_transform_iterator(slots_begin, left_flag);
+  auto partition_writer = thrust::make_tabulate_output_iterator(
+    NodeSplitPartitionWriter<DataT, LabelT, IdxT, TPB>{min_samples_leaf,
+                                                       min_impurity_decrease,
+                                                       dataset,
+                                                       work_items,
+                                                       splits,
+                                                       workload_info,
+                                                       partition_row_ids});
   thrust::exclusive_scan_by_key(
-    exec_policy, node_keys, node_keys + n_slots, left_flags, left_offsets, IdxT(0));
-
-  thrust::for_each(exec_policy, slots_begin, slots_end, [=] __device__(std::size_t slot) {
-    const auto workload_info_cta = workload_info[slot / TPB];
-    const auto nid               = workload_info_cta.nodeid;
-    const auto work_item         = work_items[nid];
-    const auto split             = splits[nid];
-    if (SplitNotValid(
-          split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
-      return;
-    }
-
-    const auto range_start = work_item.instances.begin;
-    const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * TPB + slot % TPB;
-    if (range_pos >= work_item.instances.count) { return; }
-
-    const auto row       = dataset.row_ids[range_start + range_pos];
-    const auto col_idx   = std::size_t(split.colid) * dataset.M + row;
-    const bool goes_left = dataset.data[col_idx] <= split.quesval;
-    const auto left_rank = left_offsets[slot];
-    const auto rank      = goes_left ? left_rank : IdxT(range_pos) - left_rank;
-    const auto out_idx   = range_start + (goes_left ? rank : split.nLeft + rank);
-    partition_row_ids[out_idx] = row;
-  });
+    exec_policy, node_keys, node_keys + n_slots, left_flags, partition_writer, IdxT(0));
 
   nodeSplitCopyBackKernel<DataT, LabelT, IdxT, TPB>
     <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
@@ -408,7 +426,6 @@ template void launchNodeSplitKernel<_DataT, _LabelT, _IdxT, TPB_DEFAULT>(
   const WorkloadInfo<_IdxT>* workload_info,
   size_t n_blocks_dimx,
   _IdxT* partition_row_ids,
-  _IdxT* left_offsets,
   cudaStream_t builder_stream);
 
 template void launchLeafKernel<_DatasetT, _NodeT, _ObjectiveT, _DataT>(

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
@@ -21,105 +21,18 @@ namespace DT {
 
 static constexpr int TPB_DEFAULT = 128;
 
-/**
- * @brief Partition the samples to left/right nodes based on the best split
- * @return the position of the left child node in the nodes list. However, this
- *         value is valid only for threadIdx.x == 0.
- * @note this should be called by only one block from all participating blocks
- *       'smem' should be at least of size `sizeof(IdxT) * TPB * 2`
- */
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
-DI void partitionSamples(const Dataset<DataT, LabelT, IdxT>& dataset,
-                         const Split<DataT, IdxT>& split,
-                         const NodeWorkItem& work_item,
-                         char* smem)
-{
-  typedef cub::BlockScan<int, TPB> BlockScanT;
-  __shared__ typename BlockScanT::TempStorage temp1, temp2;
-  volatile auto* row_ids = reinterpret_cast<volatile IdxT*>(dataset.row_ids);
-  // for compaction
-  size_t smemSize  = sizeof(IdxT) * TPB;
-  auto* lcomp      = reinterpret_cast<IdxT*>(smem);
-  auto* rcomp      = reinterpret_cast<IdxT*>(smem + smemSize);
-  auto range_start = work_item.instances.begin;
-  auto range_len   = work_item.instances.count;
-  auto* col        = dataset.data + split.colid * std::size_t(dataset.M);
-  auto loffset = range_start, part = loffset + split.nLeft, roffset = part;
-  auto end  = range_start + range_len;
-  int lflag = 0, rflag = 0, llen = 0, rlen = 0, minlen = 0;
-  auto tid = threadIdx.x;
-  while (loffset < part && roffset < end) {
-    // find the samples in the left that belong to right and vice-versa
-    auto loff = loffset + tid, roff = roffset + tid;
-    if (llen == minlen) lflag = loff < part ? col[row_ids[loff]] > split.quesval : 0;
-    if (rlen == minlen) rflag = roff < end ? col[row_ids[roff]] <= split.quesval : 0;
-    // scan to compute the locations for each 'misfit' in the two partitions
-    int lidx, ridx;
-    BlockScanT(temp1).ExclusiveSum(lflag, lidx, llen);
-    BlockScanT(temp2).ExclusiveSum(rflag, ridx, rlen);
-    __syncthreads();
-    minlen = llen < rlen ? llen : rlen;
-    // compaction to figure out the right locations to swap
-    if (lflag) lcomp[lidx] = loff;
-    if (rflag) rcomp[ridx] = roff;
-    __syncthreads();
-    // reset the appropriate flags for the longer of the two
-    if (lidx < minlen) lflag = 0;
-    if (ridx < minlen) rflag = 0;
-    if (llen == minlen) loffset += TPB;
-    if (rlen == minlen) roffset += TPB;
-    // swap the 'misfit's
-    if (tid < minlen) {
-      auto a              = row_ids[lcomp[tid]];
-      auto b              = row_ids[rcomp[tid]];
-      row_ids[lcomp[tid]] = b;
-      row_ids[rcomp[tid]] = a;
-    }
-  }
-}
-
-template <typename DataT, typename LabelT, typename IdxT, int TPB>
-static __global__ void nodeSplitCopySourceKernel(const IdxT min_samples_leaf,
-                                                 const IdxT min_samples_split,
-                                                 const IdxT max_leaves,
-                                                 const DataT min_impurity_decrease,
-                                                 const Dataset<DataT, LabelT, IdxT> dataset,
-                                                 const NodeWorkItem* work_items,
-                                                 const Split<DataT, IdxT>* splits,
-                                                 const WorkloadInfo<IdxT>* workload_info,
-                                                 IdxT* tmp_row_ids)
-{
-  const auto workload_info_cta = workload_info[blockIdx.x];
-  const auto nid               = workload_info_cta.nodeid;
-  const auto work_item         = work_items[nid];
-  const auto split             = splits[nid];
-  if (SplitNotValid(
-        split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
-    return;
-  }
-
-  const auto range_start = work_item.instances.begin;
-  const auto range_len   = work_item.instances.count;
-  const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * blockDim.x + threadIdx.x;
-  if (range_pos < range_len) {
-    const auto idx   = range_start + range_pos;
-    tmp_row_ids[idx] = dataset.row_ids[idx];
-  }
-}
-
-template <typename DataT, typename LabelT, typename IdxT, int TPB>
-static __global__ void nodeSplitMisfitKernel(const IdxT min_samples_leaf,
-                                             const IdxT min_samples_split,
-                                             const IdxT max_leaves,
-                                             const DataT min_impurity_decrease,
-                                             const Dataset<DataT, LabelT, IdxT> dataset,
-                                             const NodeWorkItem* work_items,
-                                             const Split<DataT, IdxT>* splits,
-                                             const WorkloadInfo<IdxT>* workload_info,
-                                             IdxT* left_counts,
-                                             IdxT* right_counts,
-                                             IdxT* left_misfit_positions,
-                                             IdxT* right_misfit_positions)
+static __global__ void nodeSplitScatterKernel(const IdxT min_samples_leaf,
+                                              const IdxT min_samples_split,
+                                              const IdxT max_leaves,
+                                              const DataT min_impurity_decrease,
+                                              const Dataset<DataT, LabelT, IdxT> dataset,
+                                              const NodeWorkItem* work_items,
+                                              const Split<DataT, IdxT>* splits,
+                                              const WorkloadInfo<IdxT>* workload_info,
+                                              IdxT* partition_row_ids,
+                                              IdxT* left_counts,
+                                              IdxT* right_counts)
 {
   typedef cub::BlockScan<int, TPB> BlockScanT;
   __shared__ typename BlockScanT::TempStorage left_scan;
@@ -141,17 +54,16 @@ static __global__ void nodeSplitMisfitKernel(const IdxT min_samples_leaf,
   const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * blockDim.x + threadIdx.x;
   const bool valid       = range_pos < range_len;
 
-  IdxT row = 0;
-  bool goes_left{false};
+  IdxT row       = 0;
+  bool goes_left = false;
   if (valid) {
     row                 = dataset.row_ids[range_start + range_pos];
     std::size_t col_idx = std::size_t(split.colid) * dataset.M + row;
     goes_left           = dataset.data[col_idx] <= split.quesval;
   }
 
-  const bool in_left_range = range_pos < std::size_t(split.nLeft);
-  const int left_flag      = valid && in_left_range && !goes_left;
-  const int right_flag     = valid && !in_left_range && goes_left;
+  const int left_flag  = valid && goes_left;
+  const int right_flag = valid && !goes_left;
 
   int left_rank, left_total;
   int right_rank, right_total;
@@ -164,47 +76,12 @@ static __global__ void nodeSplitMisfitKernel(const IdxT min_samples_leaf,
   }
   __syncthreads();
 
+  // split.nLeft is the right partition offset within this node range.
   if (left_flag) {
-    left_misfit_positions[range_start + left_base + left_rank] = range_start + range_pos;
+    partition_row_ids[range_start + left_base + left_rank] = row;
   }
   if (right_flag) {
-    right_misfit_positions[range_start + right_base + right_rank] = range_start + range_pos;
-  }
-}
-
-template <typename DataT, typename LabelT, typename IdxT, int TPB>
-static __global__ void nodeSplitSwapMisfitsKernel(const IdxT min_samples_leaf,
-                                                  const IdxT min_samples_split,
-                                                  const IdxT max_leaves,
-                                                  const DataT min_impurity_decrease,
-                                                  const Dataset<DataT, LabelT, IdxT> dataset,
-                                                  const NodeWorkItem* work_items,
-                                                  const Split<DataT, IdxT>* splits,
-                                                  const WorkloadInfo<IdxT>* workload_info,
-                                                  const IdxT* left_counts,
-                                                  const IdxT* right_counts,
-                                                  const IdxT* left_misfit_positions,
-                                                  const IdxT* right_misfit_positions,
-                                                  IdxT* tmp_row_ids)
-{
-  const auto workload_info_cta = workload_info[blockIdx.x];
-  const auto nid               = workload_info_cta.nodeid;
-  const auto work_item         = work_items[nid];
-  const auto split             = splits[nid];
-  if (SplitNotValid(
-        split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
-    return;
-  }
-
-  const auto range_start = work_item.instances.begin;
-  const auto range_len   = work_item.instances.count;
-  const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * blockDim.x + threadIdx.x;
-  const auto n_swaps     = min(left_counts[nid], right_counts[nid]);
-  if (range_pos < range_len && range_pos < std::size_t(n_swaps)) {
-    const auto left_pos    = left_misfit_positions[range_start + range_pos];
-    const auto right_pos   = right_misfit_positions[range_start + range_pos];
-    tmp_row_ids[left_pos]  = dataset.row_ids[right_pos];
-    tmp_row_ids[right_pos] = dataset.row_ids[left_pos];
+    partition_row_ids[range_start + split.nLeft + right_base + right_rank] = row;
   }
 }
 
@@ -217,7 +94,7 @@ static __global__ void nodeSplitCopyBackKernel(const IdxT min_samples_leaf,
                                                const NodeWorkItem* work_items,
                                                const Split<DataT, IdxT>* splits,
                                                const WorkloadInfo<IdxT>* workload_info,
-                                               const IdxT* tmp_row_ids)
+                                               const IdxT* partition_row_ids)
 {
   const auto workload_info_cta = workload_info[blockIdx.x];
   const auto nid               = workload_info_cta.nodeid;
@@ -233,7 +110,7 @@ static __global__ void nodeSplitCopyBackKernel(const IdxT min_samples_leaf,
   const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * blockDim.x + threadIdx.x;
   if (range_pos < range_len) {
     const auto idx       = range_start + range_pos;
-    dataset.row_ids[idx] = tmp_row_ids[idx];
+    dataset.row_ids[idx] = partition_row_ids[idx];
   }
 }
 
@@ -248,17 +125,15 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
                            const Split<DataT, IdxT>* splits,
                            const WorkloadInfo<IdxT>* workload_info,
                            size_t n_blocks_dimx,
-                           IdxT* tmp_row_ids,
+                           IdxT* partition_row_ids,
                            IdxT* left_counts,
                            IdxT* right_counts,
-                           IdxT* left_misfit_positions,
-                           IdxT* right_misfit_positions,
                            cudaStream_t builder_stream)
 {
   if (n_blocks_dimx == 0) return;
   RAFT_CUDA_TRY(cudaMemsetAsync(left_counts, 0, sizeof(IdxT) * work_items_size, builder_stream));
   RAFT_CUDA_TRY(cudaMemsetAsync(right_counts, 0, sizeof(IdxT) * work_items_size, builder_stream));
-  nodeSplitCopySourceKernel<DataT, LabelT, IdxT, TPB>
+  nodeSplitScatterKernel<DataT, LabelT, IdxT, TPB>
     <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
                                                 min_samples_split,
                                                 max_leaves,
@@ -267,34 +142,9 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
                                                 work_items,
                                                 splits,
                                                 workload_info,
-                                                tmp_row_ids);
-  nodeSplitMisfitKernel<DataT, LabelT, IdxT, TPB>
-    <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
-                                                min_samples_split,
-                                                max_leaves,
-                                                min_impurity_decrease,
-                                                dataset,
-                                                work_items,
-                                                splits,
-                                                workload_info,
+                                                partition_row_ids,
                                                 left_counts,
-                                                right_counts,
-                                                left_misfit_positions,
-                                                right_misfit_positions);
-  nodeSplitSwapMisfitsKernel<DataT, LabelT, IdxT, TPB>
-    <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
-                                                min_samples_split,
-                                                max_leaves,
-                                                min_impurity_decrease,
-                                                dataset,
-                                                work_items,
-                                                splits,
-                                                workload_info,
-                                                left_counts,
-                                                right_counts,
-                                                left_misfit_positions,
-                                                right_misfit_positions,
-                                                tmp_row_ids);
+                                                right_counts);
   nodeSplitCopyBackKernel<DataT, LabelT, IdxT, TPB>
     <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
                                                 min_samples_split,
@@ -304,7 +154,7 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
                                                 work_items,
                                                 splits,
                                                 workload_info,
-                                                tmp_row_ids);
+                                                partition_row_ids);
 }
 
 template <typename DatasetT, typename NodeT, typename ObjectiveT, typename DataT>
@@ -570,11 +420,9 @@ template void launchNodeSplitKernel<_DataT, _LabelT, _IdxT, TPB_DEFAULT>(
   const Split<_DataT, _IdxT>* splits,
   const WorkloadInfo<_IdxT>* workload_info,
   size_t n_blocks_dimx,
-  _IdxT* tmp_row_ids,
+  _IdxT* partition_row_ids,
   _IdxT* left_counts,
   _IdxT* right_counts,
-  _IdxT* left_misfit_positions,
-  _IdxT* right_misfit_positions,
   cudaStream_t builder_stream);
 
 template void launchLeafKernel<_DatasetT, _NodeT, _ObjectiveT, _DataT>(

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
@@ -11,8 +11,15 @@
 #include <raft/core/handle.hpp>
 #include <raft/util/cuda_utils.cuh>
 
+#include <rmm/exec_policy.hpp>
+
 #include <cub/cub.cuh>
 #include <thrust/binary_search.h>
+#include <thrust/execution_policy.h>
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/scan.h>
 
 #include <cstdio>
 
@@ -20,70 +27,6 @@ namespace ML {
 namespace DT {
 
 static constexpr int TPB_DEFAULT = 128;
-
-template <typename DataT, typename LabelT, typename IdxT, int TPB>
-static __global__ void nodeSplitScatterKernel(const IdxT min_samples_leaf,
-                                              const IdxT min_samples_split,
-                                              const IdxT max_leaves,
-                                              const DataT min_impurity_decrease,
-                                              const Dataset<DataT, LabelT, IdxT> dataset,
-                                              const NodeWorkItem* work_items,
-                                              const Split<DataT, IdxT>* splits,
-                                              const WorkloadInfo<IdxT>* workload_info,
-                                              IdxT* partition_row_ids,
-                                              IdxT* left_counts,
-                                              IdxT* right_counts)
-{
-  typedef cub::BlockScan<int, TPB> BlockScanT;
-  __shared__ typename BlockScanT::TempStorage left_scan;
-  __shared__ typename BlockScanT::TempStorage right_scan;
-  __shared__ IdxT left_base;
-  __shared__ IdxT right_base;
-
-  const auto workload_info_cta = workload_info[blockIdx.x];
-  const auto nid               = workload_info_cta.nodeid;
-  const auto work_item         = work_items[nid];
-  const auto split             = splits[nid];
-  if (SplitNotValid(
-        split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
-    return;
-  }
-
-  const auto range_start = work_item.instances.begin;
-  const auto range_len   = work_item.instances.count;
-  const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * blockDim.x + threadIdx.x;
-  const bool valid       = range_pos < range_len;
-
-  IdxT row       = 0;
-  bool goes_left = false;
-  if (valid) {
-    row                 = dataset.row_ids[range_start + range_pos];
-    std::size_t col_idx = std::size_t(split.colid) * dataset.M + row;
-    goes_left           = dataset.data[col_idx] <= split.quesval;
-  }
-
-  const int left_flag  = valid && goes_left;
-  const int right_flag = valid && !goes_left;
-
-  int left_rank, left_total;
-  int right_rank, right_total;
-  BlockScanT(left_scan).ExclusiveSum(left_flag, left_rank, left_total);
-  BlockScanT(right_scan).ExclusiveSum(right_flag, right_rank, right_total);
-
-  if (threadIdx.x == 0) {
-    left_base  = atomicAdd(left_counts + nid, IdxT(left_total));
-    right_base = atomicAdd(right_counts + nid, IdxT(right_total));
-  }
-  __syncthreads();
-
-  // split.nLeft is the right partition offset within this node range.
-  if (left_flag) {
-    partition_row_ids[range_start + left_base + left_rank] = row;
-  }
-  if (right_flag) {
-    partition_row_ids[range_start + split.nLeft + right_base + right_rank] = row;
-  }
-}
 
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
 static __global__ void nodeSplitCopyBackKernel(const IdxT min_samples_leaf,
@@ -126,25 +69,69 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
                            const WorkloadInfo<IdxT>* workload_info,
                            size_t n_blocks_dimx,
                            IdxT* partition_row_ids,
-                           IdxT* left_counts,
-                           IdxT* right_counts,
+                           IdxT* left_offsets,
                            cudaStream_t builder_stream)
 {
+  (void)work_items_size;
   if (n_blocks_dimx == 0) return;
-  RAFT_CUDA_TRY(cudaMemsetAsync(left_counts, 0, sizeof(IdxT) * work_items_size, builder_stream));
-  RAFT_CUDA_TRY(cudaMemsetAsync(right_counts, 0, sizeof(IdxT) * work_items_size, builder_stream));
-  nodeSplitScatterKernel<DataT, LabelT, IdxT, TPB>
-    <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
-                                                min_samples_split,
-                                                max_leaves,
-                                                min_impurity_decrease,
-                                                dataset,
-                                                work_items,
-                                                splits,
-                                                workload_info,
-                                                partition_row_ids,
-                                                left_counts,
-                                                right_counts);
+
+  const auto n_slots = n_blocks_dimx * TPB;
+  auto exec_policy   = rmm::exec_policy(builder_stream);
+  auto slots_begin   = thrust::make_counting_iterator<std::size_t>(0);
+  auto slots_end     = slots_begin + n_slots;
+
+  auto node_key = [workload_info] __host__ __device__(std::size_t slot) {
+    return workload_info[slot / TPB].nodeid;
+  };
+  auto left_predicate = [=] __host__ __device__(std::size_t slot) {
+    const auto workload_info_cta = workload_info[slot / TPB];
+    const auto nid               = workload_info_cta.nodeid;
+    const auto work_item         = work_items[nid];
+    const auto split             = splits[nid];
+    if (SplitNotValid(
+          split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
+      return false;
+    }
+
+    const auto range_pos = std::size_t(workload_info_cta.offset_blockid) * TPB + slot % TPB;
+    if (range_pos >= work_item.instances.count) { return false; }
+
+    const auto row     = dataset.row_ids[work_item.instances.begin + range_pos];
+    const auto col_idx = std::size_t(split.colid) * dataset.M + row;
+    return dataset.data[col_idx] <= split.quesval;
+  };
+
+  auto node_keys = thrust::make_transform_iterator(slots_begin, node_key);
+  auto left_flag = [left_predicate] __host__ __device__(std::size_t slot) {
+    return left_predicate(slot) ? IdxT(1) : IdxT(0);
+  };
+  auto left_flags = thrust::make_transform_iterator(slots_begin, left_flag);
+  thrust::exclusive_scan_by_key(
+    exec_policy, node_keys, node_keys + n_slots, left_flags, left_offsets, IdxT(0));
+
+  thrust::for_each(exec_policy, slots_begin, slots_end, [=] __device__(std::size_t slot) {
+    const auto workload_info_cta = workload_info[slot / TPB];
+    const auto nid               = workload_info_cta.nodeid;
+    const auto work_item         = work_items[nid];
+    const auto split             = splits[nid];
+    if (SplitNotValid(
+          split, min_impurity_decrease, min_samples_leaf, IdxT(work_item.instances.count))) {
+      return;
+    }
+
+    const auto range_start = work_item.instances.begin;
+    const auto range_pos   = std::size_t(workload_info_cta.offset_blockid) * TPB + slot % TPB;
+    if (range_pos >= work_item.instances.count) { return; }
+
+    const auto row       = dataset.row_ids[range_start + range_pos];
+    const auto col_idx   = std::size_t(split.colid) * dataset.M + row;
+    const bool goes_left = dataset.data[col_idx] <= split.quesval;
+    const auto left_rank = left_offsets[slot];
+    const auto rank      = goes_left ? left_rank : IdxT(range_pos) - left_rank;
+    const auto out_idx   = range_start + (goes_left ? rank : split.nLeft + rank);
+    partition_row_ids[out_idx] = row;
+  });
+
   nodeSplitCopyBackKernel<DataT, LabelT, IdxT, TPB>
     <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
                                                 min_samples_split,
@@ -421,8 +408,7 @@ template void launchNodeSplitKernel<_DataT, _LabelT, _IdxT, TPB_DEFAULT>(
   const WorkloadInfo<_IdxT>* workload_info,
   size_t n_blocks_dimx,
   _IdxT* partition_row_ids,
-  _IdxT* left_counts,
-  _IdxT* right_counts,
+  _IdxT* left_offsets,
   cudaStream_t builder_stream);
 
 template void launchLeafKernel<_DatasetT, _NodeT, _ObjectiveT, _DataT>(

--- a/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
+++ b/cpp/src/decisiontree/batched-levelalgo/kernels/builder_kernels_impl.cuh
@@ -28,6 +28,9 @@ namespace DT {
 
 static constexpr int TPB_DEFAULT = 128;
 
+// Output side of the segmented partition scan. The scan supplies the
+// exclusive left rank for each logical row slot in its node segment; this
+// writer uses that rank to place the row into the temporary partition buffer.
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
 struct NodeSplitPartitionWriter {
   IdxT min_samples_leaf;
@@ -57,16 +60,17 @@ struct NodeSplitPartitionWriter {
     const auto row       = dataset.row_ids[range_start + range_pos];
     const auto col_idx   = std::size_t(split.colid) * dataset.M + row;
     const bool goes_left = dataset.data[col_idx] <= split.quesval;
+    // Previous right rows are the previous rows in this node minus previous left rows.
     const auto rank      = goes_left ? left_rank : IdxT(range_pos) - left_rank;
     const auto out_idx   = range_start + (goes_left ? rank : split.nLeft + rank);
     partition_row_ids[out_idx] = row;
   }
 };
 
+// Copy back only ranges for nodes that actually split. Leaf/invalid nodes keep
+// their existing row-id order because the scan writer skips them too.
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
 static __global__ void nodeSplitCopyBackKernel(const IdxT min_samples_leaf,
-                                               const IdxT min_samples_split,
-                                               const IdxT max_leaves,
                                                const DataT min_impurity_decrease,
                                                const Dataset<DataT, LabelT, IdxT> dataset,
                                                const NodeWorkItem* work_items,
@@ -94,21 +98,19 @@ static __global__ void nodeSplitCopyBackKernel(const IdxT min_samples_leaf,
 
 template <typename DataT, typename LabelT, typename IdxT, int TPB>
 void launchNodeSplitKernel(const IdxT min_samples_leaf,
-                           const IdxT min_samples_split,
-                           const IdxT max_leaves,
                            const DataT min_impurity_decrease,
                            const Dataset<DataT, LabelT, IdxT>& dataset,
                            const NodeWorkItem* work_items,
-                           size_t work_items_size,
                            const Split<DataT, IdxT>* splits,
                            const WorkloadInfo<IdxT>* workload_info,
                            size_t n_blocks_dimx,
                            IdxT* partition_row_ids,
                            cudaStream_t builder_stream)
 {
-  (void)work_items_size;
   if (n_blocks_dimx == 0) return;
 
+  // Each slot corresponds to one thread lane in the tiled workload_info layout.
+  // workload_info is grouped by node, so scan-by-key resets ranks at node boundaries.
   const auto n_slots = n_blocks_dimx * TPB;
   auto exec_policy   = rmm::exec_policy(builder_stream);
   auto slots_begin   = thrust::make_counting_iterator<std::size_t>(0);
@@ -134,6 +136,9 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
     return dataset.data[col_idx] <= split.quesval;
   };
 
+  // The scan input is a stream of per-slot left flags keyed by node id.
+  // The scan output is a tabulated writer, so partition_row_ids is populated
+  // during the scan rather than by a second scatter kernel.
   auto node_keys = thrust::make_transform_iterator(slots_begin, node_key);
   auto left_flag = [left_predicate] __host__ __device__(std::size_t slot) {
     return left_predicate(slot) ? IdxT(1) : IdxT(0);
@@ -150,10 +155,9 @@ void launchNodeSplitKernel(const IdxT min_samples_leaf,
   thrust::exclusive_scan_by_key(
     exec_policy, node_keys, node_keys + n_slots, left_flags, partition_writer, IdxT(0));
 
+  // The original row_ids buffer remains the source during the scan, so copy back after it finishes.
   nodeSplitCopyBackKernel<DataT, LabelT, IdxT, TPB>
     <<<n_blocks_dimx, TPB, 0, builder_stream>>>(min_samples_leaf,
-                                                min_samples_split,
-                                                max_leaves,
                                                 min_impurity_decrease,
                                                 dataset,
                                                 work_items,
@@ -416,12 +420,9 @@ void launchComputeSplitKernel(BinT* histograms,
 
 template void launchNodeSplitKernel<_DataT, _LabelT, _IdxT, TPB_DEFAULT>(
   const _IdxT min_samples_leaf,
-  const _IdxT min_samples_split,
-  const _IdxT max_leaves,
   const _DataT min_impurity_decrease,
   const Dataset<_DataT, _LabelT, _IdxT>& dataset,
   const NodeWorkItem* work_items,
-  size_t work_items_size,
   const Split<_DataT, _IdxT>* splits,
   const WorkloadInfo<_IdxT>* workload_info,
   size_t n_blocks_dimx,


### PR DESCRIPTION
## Summary

This replaces RF row partitioning with a Thrust scan-based segmented partition.

The partition step now runs `exclusive_scan_by_key` over the existing row-tiled `workload_info` layout, using node id as the scan key. For each row slot, the scan counts prior rows that go left within that node segment. The output iterator uses that rank to write the row directly into its partitioned position in a temporary row-id buffer; right-side rank is derived from `range_pos - left_rank`. After the scan, a lightweight copyback writes the partitioned ranges back to `dataset.row_ids`.

The important effect is work distribution. The old implementation launched one block per node and performed in-place misfit swapping, which becomes poorly distributed in deep trees. The new path distributes work by row tiles, so deep-tree partitioning keeps more GPU work available and avoids the one-block-per-node bottleneck.

## Changes

- Replace the in-place node partition kernel with a segmented scan partition.
- Reuse `workload_info` to key row slots by node.
- Add a single temporary row-id buffer for out-of-place partition output.
- Remove unused partition launch arguments and old partition helper code.
- Add comments documenting the scan/partition structure.

## Benchmarks

Local covtype deep RF benchmark, cuML `RandomForestClassifier`, full dataset:

- `n_train=464809`, `n_test=116203`, `n_features=54`
- `n_estimators=100`, `max_depth=30`, `n_bins=128`, `n_streams=4`
- `random_state=42`, default Python RF `max_batch_size=4096`
- Reported metric is `fit_seconds`, 3 repeats.

| max_features | baseline median | this PR median | speedup |
| --- | ---: | ---: | ---: |
| `sqrt` | 1.457 s | 1.144 s | 1.27x |
| all features | 7.104 s | 3.652 s | 1.95x |

Warm-repeat mean, excluding repeat 0:

| max_features | baseline | this PR | speedup |
| --- | ---: | ---: | ---: |
| `sqrt` | 1.441 s | 1.138 s | 1.27x |
| all features | 7.100 s | 3.703 s | 1.92x |

Accuracy was unchanged in these runs:

- `sqrt`: `0.865373527`
- all features: `0.963839144`

## Validation

- `git diff --check`
- `conda run -n cuml_dev ninja -C /home/rorym/cuml-builds/codex-rf-partitioning-fix/cpp-release-ninja cuml`
